### PR TITLE
Postgres 15 compatibility, various warnings fixes and more

### DIFF
--- a/pg4wp/driver_pgsql_install.php
+++ b/pg4wp/driver_pgsql_install.php
@@ -228,9 +228,9 @@ $sql = "SELECT pg_attribute.attname AS \"Field\",
 		ELSE 'YES'
 	END AS \"Null\",
 	CASE pg_type.typname
-		WHEN 'varchar' THEN substring(pg_attrdef.adsrc FROM '^''(.*)''.*$')
-		WHEN 'timestamp' THEN CASE WHEN pg_attrdef.adsrc LIKE '%now()%' THEN '0000-00-00 00:00:00' ELSE pg_attrdef.adsrc END
-		ELSE pg_attrdef.adsrc
+		WHEN 'varchar' THEN substring(pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) FROM '^''(.*)''.*$')
+		WHEN 'timestamp' THEN CASE WHEN pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) LIKE '%now()%' THEN '0000-00-00 00:00:00' ELSE pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) END
+		ELSE pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) 
 	END AS \"Default\"
 FROM pg_class
 	INNER JOIN pg_attribute


### PR DESCRIPTION
This PR includes various fixes for postgres 15 compatibility

- Pass Connection to Postgres commands explicitly as it's deprecated to implicitly get it
- Corrects a bug in FOUND rows which was trimming 1=1 from WHERE 1=1 in various queries
- No longer incorrectly calls pg_result_status on FALSE
- No longer calls to adsrc which doesn't exist anymore 
