### PR TITLE
PHP 8 / WP 6+ compatibility fixes

### DIFF
--- a/pg4wp/db.php
+++ b/pg4wp/db.php
@@ -9,32 +9,43 @@ Author URI: http://www.hawkix.net
 License: GPLv2 or newer.
 */
 
-if( !defined('PG4WP_ROOT'))
-{
-// You can choose the driver to load here
-define('DB_DRIVER', 'pgsql'); // 'pgsql' or 'mysql' are supported for now
+// Ensure we only load this config once
+if(!defined('PG4WP_ROOT')) {
 
-// Set this to 'true' and check that `pg4wp` is writable if you want debug logs to be written
-define( 'PG4WP_DEBUG', false);
-// If you just want to log queries that generate errors, leave PG4WP_DEBUG to "false"
-// and set this to true
-define( 'PG4WP_LOG_ERRORS', true);
+    // You can choose the driver to load here
+    if (!defined('DB_DRIVER')) {
+        define('DB_DRIVER', pgsql);
+    }
 
-// If you want to allow insecure configuration (from the author point of view) to work with PG4WP,
-// change this to true
-define( 'PG4WP_INSECURE', false);
+    // Set this to 'true' and check that `pg4wp` is writable if you want debug logs to be written
+    if (!defined('PG4WP_DEBUG')) {
+        define('PG4WP_DEBUG', false);
+    }
 
-// This defines the directory where PG4WP files are loaded from
-//   3 places checked : wp-content, wp-content/plugins and the base directory
-if( file_exists( ABSPATH.'/wp-content/pg4wp'))
-	define( 'PG4WP_ROOT', ABSPATH.'/wp-content/pg4wp');
-else if( file_exists( ABSPATH.'/wp-content/plugins/pg4wp'))
-	define( 'PG4WP_ROOT', ABSPATH.'/wp-content/plugins/pg4wp');
-else if( file_exists( ABSPATH.'/pg4wp'))
-	define( 'PG4WP_ROOT', ABSPATH.'/pg4wp');
-else
-	die('PG4WP file directory not found');
+    if (!defined('PG4WP_LOG_ERRORS')) {
+        // If you just want to log queries that generate errors, leave PG4WP_DEBUG to "false"
+        // and set this to true
+        define('PG4WP_LOG_ERRORS', true);
+    }
 
-// Here happens all the magic
-require_once( PG4WP_ROOT.'/core.php');
+    if (!defined('PG4WP_INSECURE')) {
+        // If you want to allow insecure configuration (from the author point of view) to work with PG4WP,
+        // change this to true
+        define('PG4WP_INSECURE', false);
+    }
+
+    // This defines the directory where PG4WP files are loaded from
+    //   3 places checked : wp-content, wp-content/plugins and the base directory
+    if(file_exists(ABSPATH . '/wp-content/pg4wp')) {
+        define('PG4WP_ROOT', ABSPATH . '/wp-content/pg4wp');
+    } elseif(file_exists(ABSPATH . '/wp-content/plugins/pg4wp')) {
+        define('PG4WP_ROOT', ABSPATH . '/wp-content/plugins/pg4wp');
+    } elseif(file_exists(ABSPATH . '/pg4wp')) {
+        define('PG4WP_ROOT', ABSPATH . '/pg4wp');
+    } else {
+        die('PG4WP file directory not found');
+    }
+
+    // Here happens all the magic
+    require_once(PG4WP_ROOT . '/core.php');
 } // Protection against multiple loading


### PR DESCRIPTION
This PR attempts to address issues with PHP 8 and WP 6+ compatibility

- PHP 8.1 is_resource no longer correctly detects postgres results: See https://php.watch/versions/8.1/PgSQL-resource

All functions from the PostgreSQL extension that previously returned a resource object now return a class object, and their counterpart functions also accept the same class objects.

Note that the is_resource function no longer returns true for the new class objects, and it may now be necessary to change the is_resource check with a comparison to false, or account for the new class instances as well.


- wp-db.php is updated to class-wpdb.php

- All constants definitions now check if already defined so they can be set via wp-config.php instead of db.php