### PR TITLE
Implement "SHOW COLUMNS" rewrite

### DIFF
--- a/pg4wp/driver_pgsql_rewrite.php
+++ b/pg4wp/driver_pgsql_rewrite.php
@@ -12,7 +12,7 @@ spl_autoload_register(function ($className) {
 function createSQLRewriter(string $sql): AbstractSQLRewriter
 {
     $sql = trim($sql);
-    if (preg_match('/^(SELECT|INSERT|REPLACE INTO|UPDATE|DELETE|DESCRIBE|ALTER TABLE|CREATE TABLE|DROP TABLE|SHOW INDEX|SHOW VARIABLES|SHOW TABLES|OPTIMIZE TABLE|SET NAMES|SHOW FULL COLUMNS|SHOW TABLE STATUS)\b/i', $sql, $matches)) {
+    if (preg_match('/^(SELECT|INSERT|REPLACE INTO|UPDATE|DELETE|DESCRIBE|ALTER TABLE|CREATE TABLE|DROP TABLE|SHOW INDEX|SHOW VARIABLES|SHOW TABLES|OPTIMIZE TABLE|SET NAMES|SHOW FULL COLUMNS|SHOW COLUMNS|SHOW TABLE STATUS)\b/i', $sql, $matches)) {
         // Convert to a format suitable for class names (e.g., "SHOW TABLES" becomes "ShowTables")
         $type = str_replace(' ', '', ucwords(str_replace('_', ' ', strtolower($matches[1]))));
         $className = $type . 'SQLRewriter';

--- a/pg4wp/rewriters/ShowColumnsSQLRewriter.php
+++ b/pg4wp/rewriters/ShowColumnsSQLRewriter.php
@@ -1,0 +1,71 @@
+<?php
+
+class ShowColumnsSQLRewriter extends AbstractSQLRewriter
+{
+    public function rewrite(): string
+    {
+        $sql = $this->original();
+        $table = $this->extractTableNameFromShowColumns($sql);
+        return $this->generatePostgresShowColumns($table);
+    }
+
+    /**
+     * Extracts table name from a "SHOW COLUMNS" SQL statement.
+     *
+     * @param string $sql The SQL statement
+     * @return string|null The table name if found, or null otherwise
+     */
+    protected function extractTableNameFromShowColumns($sql)
+    {
+        $pattern = "/SHOW COLUMNS FROM ['\"`]?([^'\"`]+)['\"`]?/i";
+        if (preg_match($pattern, $sql, $matches)) {
+            return $matches[1];
+        }
+        return null;
+    }
+
+    /**
+     * Generates a PostgreSQL-compatible SQL query to mimic MySQL's "SHOW COLUMNS".
+     *
+     * @param string $tableName The table name
+     * @param string $schema The schema name
+     * @return string The generated SQL query
+     */
+    public function generatePostgresShowColumns($tableName, $schema = "public")
+    {
+        $sql = <<<SQL
+            SELECT 
+                a.attname AS "Field",
+                pg_catalog.format_type(a.atttypid, a.atttypmod) AS "Type",
+                (CASE 
+                    WHEN a.attnotnull THEN 'NO' 
+                    ELSE 'YES' 
+                END) AS "Null",
+                (CASE 
+                    WHEN i.indisprimary THEN 'PRI'
+                    WHEN i.indisunique THEN 'UNI'
+                    ELSE '' 
+                END) AS "Key",
+                pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) AS "Default",
+                '' AS "Extra",
+            FROM 
+                pg_catalog.pg_attribute a
+                LEFT JOIN pg_catalog.pg_attrdef ad ON (a.attrelid = ad.adrelid AND a.attnum = ad.adnum)
+                LEFT JOIN pg_catalog.pg_index i ON (a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey))
+            WHERE 
+                a.attnum > 0 
+                AND NOT a.attisdropped
+                AND a.attrelid = (
+                    SELECT c.oid
+                    FROM pg_catalog.pg_class c
+                    LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                    WHERE c.relname = '$tableName'
+                    AND n.nspname = '$schema'
+                )
+            ORDER BY 
+                a.attnum;
+        SQL;
+
+        return $sql;
+    }
+}


### PR DESCRIPTION
Related Issues:
 - Complianz-GDPR uses `SHOW COLUMNS`, currently only `SHOW FULL COLUMNS` is implemented

Added Tests:
 -