### PR TITLE
remove key names which are not supported during key creation in postgres

### DIFF
--- a/pg4wp/rewriters/CreateTableSQLRewriter.php
+++ b/pg4wp/rewriters/CreateTableSQLRewriter.php
@@ -82,8 +82,14 @@ class CreateTableSQLRewriter extends AbstractSQLRewriter
         $sql = preg_replace($pattern, '', $sql);
 
 
+        // Rewrite unique keys to just be UNIQUE without a key name
         $pattern = "/(,\s*)?UNIQUE KEY\s+[a-zA-Z0-9_]+\s+(\([a-zA-Z0-9_,\s]+\))/";
         $replacement = "$1UNIQUE $2";
+        $sql = preg_replace($pattern, $replacement, $sql);
+
+        // Rewrite Primary keys to not have a key name
+        $pattern = '/PRIMARY KEY\s+\w+\s*\((.*?)\)/';
+        $replacement = 'PRIMARY KEY ($1)';
         $sql = preg_replace($pattern, $replacement, $sql);
 
         return $sql;

--- a/tests/rewriteTest.php
+++ b/tests/rewriteTest.php
@@ -702,7 +702,7 @@ final class rewriteTest extends TestCase
                 mysqlcolumn_detail text NOT NULL DEFAULT '',
                 type varchar(210) NOT NULL DEFAULT 'post',
                 item bigint NOT NULL DEFAULT '0',
-                PRIMARY KEY doctermitem (doc, term, item)
+                PRIMARY KEY (doc, term, item)
                 );
         SQL;
 


### PR DESCRIPTION
Related Issues:
 - https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/issues/78

Added Tests:
 - Added a test to remove primary key name