### PR TITLE
replace regexp with its postgres version

### DIFF
--- a/pg4wp/rewriters/SelectSQLRewriter.php
+++ b/pg4wp/rewriters/SelectSQLRewriter.php
@@ -65,6 +65,9 @@ class SelectSQLRewriter extends AbstractSQLRewriter
         // Handle COUNT(*)...ORDER BY...
         $sql = preg_replace('/COUNT(.+)ORDER BY.+/s', 'COUNT$1', $sql);
 
+        // HANDLE REGEXP
+        $sql = preg_replace('/REGEXP/', '~', $sql);
+
         // In order for users counting to work...
         $matches = array();
         if(preg_match_all('/COUNT[^C]+\),/', $sql, $matches)) {

--- a/tests/rewriteTest.php
+++ b/tests/rewriteTest.php
@@ -724,9 +724,9 @@ final class rewriteTest extends TestCase
             )
             GROUP BY wp_posts.ID
             ORDER BY wp_postmeta.meta_value+0 DESC, wp_posts.post_date DESC
-    SQL;
+        SQL;
 
-    $expected = <<<SQL
+        $expected = <<<SQL
             SELECT   wp_posts.* FROM wp_posts  INNER JOIN wp_postmeta ON ( wp_posts."ID" = wp_postmeta.post_id )
             WHERE 1=1  AND ( 
                 wp_posts.post_date > '2024-07-17 23:59:59'
@@ -737,14 +737,25 @@ final class rewriteTest extends TestCase
             )
             
             ORDER BY CAST(wp_postmeta.meta_value AS INTEGER) DESC, wp_posts.post_date DESC
-    SQL;
+        SQL;
 
-    $postgresql = pg4wp_rewrite($sql);
-    $this->assertSame(trim($expected), trim($postgresql));
+        $postgresql = pg4wp_rewrite($sql);
+        $this->assertSame(trim($expected), trim($postgresql));
     }
 
+    public function test_it_rewrites_regexp() 
+    {
+        $sql = <<<SQL
+            SELECT DISTINCT meta_key FROM wp_gf_entry_meta WHERE form_id=2 AND meta_key REGEXP '^[0-9]+(\.[0-9]+)?$'
+        SQL;
 
+        $expected = <<<SQL
+            SELECT DISTINCT meta_key FROM wp_gf_entry_meta WHERE form_id=2 AND meta_key ~ '^[0-9]+(\.[0-9]+)?$'
+        SQL;
 
+        $postgresql = pg4wp_rewrite($sql);
+        $this->assertSame(trim($expected), trim($postgresql));
+    }
 
     
 


### PR DESCRIPTION
Related Issues:
 - https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/issues/129

Added Tests:
 - Added a test to make sure we replace REGEXP