### PR TITLE
rewrite utc timestamp requests

### DIFF
--- a/pg4wp/rewriters/InsertSQLRewriter.php
+++ b/pg4wp/rewriters/InsertSQLRewriter.php
@@ -11,6 +11,8 @@ class InsertSQLRewriter extends AbstractSQLRewriter
         // Those are used when we need to set the date to now() in gmt time
         $sql = str_replace("'0000-00-00 00:00:00'", 'now() AT TIME ZONE \'gmt\'', $sql);
 
+        $sql = str_replace("utc_timestamp()", "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'", $sql);
+
         // Multiple values group when calling INSERT INTO don't always work
         if(false !== strpos($sql, $wpdb->options) && false !== strpos($sql, '), (')) {
             $pattern = '/INSERT INTO.+VALUES/';

--- a/pg4wp/rewriters/SelectSQLRewriter.php
+++ b/pg4wp/rewriters/SelectSQLRewriter.php
@@ -68,6 +68,8 @@ class SelectSQLRewriter extends AbstractSQLRewriter
         // HANDLE REGEXP
         $sql = preg_replace('/REGEXP/', '~', $sql);
 
+        $sql = str_replace("utc_timestamp()", "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'", $sql);
+
         // In order for users counting to work...
         $matches = array();
         if(preg_match_all('/COUNT[^C]+\),/', $sql, $matches)) {

--- a/tests/rewriteTest.php
+++ b/tests/rewriteTest.php
@@ -757,7 +757,33 @@ final class rewriteTest extends TestCase
         $this->assertSame(trim($expected), trim($postgresql));
     }
 
-    
+    public function test_it_rewrites_utc_timestamp_inserts() 
+    {
+        $sql = <<<SQL
+            INSERT INTO wp_gf_form(title, date_created) VALUES('Test', utc_timestamp())
+        SQL;
+
+        $expected = <<<SQL
+            INSERT INTO wp_gf_form(title, date_created) VALUES('Test', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') RETURNING *
+        SQL;
+
+        $postgresql = pg4wp_rewrite($sql);
+        $this->assertSame(trim($expected), trim($postgresql));
+    }
+
+    public function test_it_rewrites_utc_timestamp_selects() 
+    {
+        $sql = <<<SQL
+            SELECT utc_timestamp()
+        SQL;
+
+        $expected = <<<SQL
+            SELECT CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+        SQL;
+
+        $postgresql = pg4wp_rewrite($sql);
+        $this->assertSame(trim($expected), trim($postgresql));
+    }
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Related Issues:
 - Closes https://github.com/PostgreSQL-For-Wordpress/postgresql-for-wordpress/issues/128

Added Tests:
 - utc_timestamp is replaced on select and insert